### PR TITLE
feat: pnpm workspace setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 .DS_Store
+
+yarn.lock
+package-lock.json

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

- pnpm을 이용하고 있기 때문에 `yarn.lock`, `package-lock.josn`을 `.gitignore`에 추가해줬습니다.
- `pnpm-workspace.yaml` 파일을 생성해서 workspace 기본 세팅을 해줬습니다.